### PR TITLE
Authentication

### DIFF
--- a/back/pom.xml
+++ b/back/pom.xml
@@ -94,11 +94,11 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-tomcat</artifactId>
-			<scope>provided</scope>
-		</dependency>
+<!--		<dependency>-->
+<!--			<groupId>org.springframework.boot</groupId>-->
+<!--			<artifactId>spring-boot-starter-tomcat</artifactId>-->
+<!--			<scope>provided</scope>-->
+<!--		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
@@ -109,7 +109,24 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.5</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/back/src/main/java/rs/map/pki/config/DataSeeder.java
+++ b/back/src/main/java/rs/map/pki/config/DataSeeder.java
@@ -1,0 +1,28 @@
+package rs.map.pki.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+//import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import rs.map.pki.model.User;
+import rs.map.pki.repository.UserRepository;
+
+import java.util.List;
+
+//@Profile()
+@RequiredArgsConstructor
+@Component
+public class DataSeeder implements CommandLineRunner {
+    private final UserRepository users;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(String... args) throws Exception {
+        var users = List.of(
+                new User(null, "admin@map.rs", passwordEncoder.encode("securepassword"),"Admin", "Adminović", "MAP", User.Role.ROLE_ADMIN)
+        );
+
+        this.users.saveAllAndFlush(users);
+    }
+}

--- a/back/src/main/java/rs/map/pki/config/FrontProperties.java
+++ b/back/src/main/java/rs/map/pki/config/FrontProperties.java
@@ -1,0 +1,12 @@
+package rs.map.pki.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "front")
+public class FrontProperties {
+    private String url;
+}

--- a/back/src/main/java/rs/map/pki/config/JwtProperties.java
+++ b/back/src/main/java/rs/map/pki/config/JwtProperties.java
@@ -1,0 +1,16 @@
+package rs.map.pki.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private String secret;
+    private Duration accessExpiration, refreshExpiration;
+}

--- a/back/src/main/java/rs/map/pki/config/SecurityConfig.java
+++ b/back/src/main/java/rs/map/pki/config/SecurityConfig.java
@@ -1,0 +1,80 @@
+package rs.map.pki.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import rs.map.pki.filter.AuthFilter;
+
+import java.util.List;
+
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+    private final FrontProperties frontProperties;
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    AuthenticationProvider authenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        var provider = new DaoAuthenticationProvider(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder);
+        return provider;
+    }
+
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        var config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of(frontProperties.getUrl()));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        var source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource, AuthenticationProvider authenticationProvider, AuthFilter authFilter) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/controller/AuthController.java
+++ b/back/src/main/java/rs/map/pki/controller/AuthController.java
@@ -1,0 +1,79 @@
+package rs.map.pki.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.*;
+import rs.map.pki.config.JwtProperties;
+import rs.map.pki.dto.LoginRequestDto;
+import rs.map.pki.dto.TokenResponseDto;
+import rs.map.pki.model.User;
+import rs.map.pki.util.JwtUtil;
+import rs.map.pki.util.PkiUserDetails;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(path = {"/api/auth"}, produces = MediaType.APPLICATION_JSON_VALUE)
+public class AuthController {
+    private final AuthenticationManager authManager;
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    // POST auth/login
+    @PostMapping("/login")
+    ResponseEntity<TokenResponseDto> login(
+            @RequestBody @Valid LoginRequestDto request,
+            JwtProperties jwtProperties
+    ) {
+        var auth = authManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+        );
+
+        var userDetails = (UserDetails) auth.getPrincipal();
+        String accessToken = jwtUtil.generateAccessToken(userDetails);
+        String refreshToken = jwtUtil.generateRefreshToken(userDetails);
+
+        String cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/api/auth/refresh")
+                .maxAge(jwtProperties.getRefreshExpiration())
+                .sameSite("Strict")
+                .build()
+                .toString();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie)
+                .body(new TokenResponseDto(accessToken));
+    }
+
+    // POST auth/refresh
+    @PostMapping("/refresh")
+    ResponseEntity<TokenResponseDto> refresh(
+            @CookieValue(name = "refreshToken", required = false) String refreshToken
+    ) {
+        if (refreshToken == null || !jwtUtil.isTokenValid(refreshToken)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        String username = jwtUtil.extractUsername(refreshToken);
+        var userDetails = userDetailsService.loadUserByUsername(username);
+
+        String newAccessToken = jwtUtil.generateAccessToken(userDetails);
+        return ResponseEntity.ok(new TokenResponseDto(newAccessToken));
+    }
+
+    // GET auth/whoami
+    @GetMapping("/whoami")
+    User whoami(@AuthenticationPrincipal PkiUserDetails principal) {
+        // TODO: maybe make a user dto
+        return principal.getUser();
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/controller/RegistrationController.java
+++ b/back/src/main/java/rs/map/pki/controller/RegistrationController.java
@@ -1,0 +1,28 @@
+package rs.map.pki.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(path = {"/auth"}, produces = MediaType.APPLICATION_JSON_VALUE)
+public class RegistrationController {
+
+    // POST auth/register
+
+    // POST admin@auth/register/<role>
+    @PostMapping("/register/{role:^(admin|ca|simpson)$}")
+    ResponseEntity<?> adminRegisterUser(
+            @PathVariable String role,
+            Object data
+    ) {
+        return null;
+    }
+
+    // POST auth/activate?token=<activation_token>
+    // GET auth/activate?token=<activation_token>
+
+}

--- a/back/src/main/java/rs/map/pki/dto/LoginRequestDto.java
+++ b/back/src/main/java/rs/map/pki/dto/LoginRequestDto.java
@@ -1,0 +1,16 @@
+package rs.map.pki.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+
+@Data
+public class LoginRequestDto {
+
+    @NotBlank(message = "{login.email.blank}")
+    private String email;
+
+    @NotBlank(message = "{login.password.blank")
+    private String password;
+
+}

--- a/back/src/main/java/rs/map/pki/dto/TokenResponseDto.java
+++ b/back/src/main/java/rs/map/pki/dto/TokenResponseDto.java
@@ -1,0 +1,9 @@
+package rs.map.pki.dto;
+
+import lombok.Data;
+
+
+@Data
+public class TokenResponseDto {
+    private final String accessToken;
+}

--- a/back/src/main/java/rs/map/pki/filter/AuthFilter.java
+++ b/back/src/main/java/rs/map/pki/filter/AuthFilter.java
@@ -1,0 +1,54 @@
+package rs.map.pki.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import rs.map.pki.util.JwtUtil;
+
+import java.io.IOException;
+import java.util.Optional;
+
+
+@RequiredArgsConstructor
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+    private static final String
+            HEADER_AUTH = "Authorization",
+            AUTH_TYPE = "Bearer";
+
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        Optional.ofNullable(request.getHeader(HEADER_AUTH))
+                .filter(authHeader -> authHeader.startsWith(AUTH_TYPE + " "))
+                .map(authHeader -> authHeader.substring(AUTH_TYPE.length() + " ".length()))
+                .filter(jwtUtil::isTokenValid)
+                .map(jwtUtil::extractUsername)
+                .map(userDetailsService::loadUserByUsername)
+                .ifPresent(userDetails -> {
+                    var auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                });
+
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/model/User.java
+++ b/back/src/main/java/rs/map/pki/model/User.java
@@ -1,0 +1,54 @@
+package rs.map.pki.model;
+
+import java.util.UUID;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotBlank(message = "{user.email.blank}")
+    @Email(message = "{user.email.invalid}")
+    private String email;
+
+    @NotBlank(message = "{user.password.blank}")
+    @Size(min = 8, max = 64, message = "{user.password.size}")
+    private String password;
+
+    @NotBlank(message = "{user.name.blank}")
+    private String name;
+
+    @NotBlank(message = "{user.surname.blank}")
+    private String surname;
+
+    @NotBlank(message = "{user.organization.blank}")
+    private String organization;
+
+    @NotNull(message = "{user.role.null}")
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Transient
+    public String getFullName() {
+        return name + " " + surname;
+    }
+
+    public static enum Role {
+        ROLE_ADMIN, ROLE_CA, ROLE_SIMPSON
+    }
+}

--- a/back/src/main/java/rs/map/pki/repository/UserRepository.java
+++ b/back/src/main/java/rs/map/pki/repository/UserRepository.java
@@ -1,0 +1,19 @@
+package rs.map.pki.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import rs.map.pki.model.User;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByEmailIgnoreCase(String email);
+
+    default Optional<User> findByEmail(String email) {
+        return findByEmailIgnoreCase(email);
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/service/PkiUserDetailsService.java
+++ b/back/src/main/java/rs/map/pki/service/PkiUserDetailsService.java
@@ -1,0 +1,24 @@
+package rs.map.pki.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import rs.map.pki.repository.UserRepository;
+import rs.map.pki.util.PkiUserDetails;
+
+
+@RequiredArgsConstructor
+@Service
+public class PkiUserDetailsService implements UserDetailsService {
+    private final UserRepository users;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return users.findByEmail(email)
+                .map(PkiUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/util/JwtUtil.java
+++ b/back/src/main/java/rs/map/pki/util/JwtUtil.java
@@ -1,0 +1,91 @@
+package rs.map.pki.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.stereotype.Component;
+import rs.map.pki.config.JwtProperties;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.util.Date;
+
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey signingKey;
+    private final JwtProperties jwtProperties;
+
+
+    @Autowired
+    public JwtUtil(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+
+        var secret = Hex.decode(jwtProperties.getSecret());
+        signingKey = Keys.hmacShaKeyFor(secret);
+    }
+
+
+    public String generateAccessToken(UserDetails userDetails) {
+        return generateToken(userDetails, jwtProperties.getAccessExpiration());
+    }
+
+    public String generateRefreshToken(UserDetails userDetails) {
+        return generateToken(userDetails, jwtProperties.getRefreshExpiration());
+    }
+
+    private String generateToken(UserDetails userDetails, Duration expiration) {
+        var now = new Date();
+        var notAfter = new Date(now.getTime() + expiration.toMillis());
+
+        return Jwts.builder()
+                .subject(userDetails.getUsername())
+                .claim("roles", userDetails.getAuthorities().stream().map(GrantedAuthority::getAuthority).toList())
+                .issuedAt(now)
+                .expiration(notAfter)
+                .signWith(signingKey)
+                .compact();
+    }
+
+    @Nullable
+    public String extractUsername(String jwt) {
+        try {
+            return extractClaims(jwt).getSubject();
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public Date extractExpiration(String jwt) {
+        try {
+            return extractClaims(jwt).getExpiration();
+        } catch (JwtException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    public boolean isTokenValid(String jwt) {
+        try {
+            var claims = extractClaims(jwt);
+            return claims.getExpiration() != null && claims.getExpiration().after(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Claims extractClaims(String jwt) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload();
+    }
+
+}

--- a/back/src/main/java/rs/map/pki/util/PkiUserDetails.java
+++ b/back/src/main/java/rs/map/pki/util/PkiUserDetails.java
@@ -1,0 +1,35 @@
+package rs.map.pki.util;
+
+import java.util.Collection;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import lombok.RequiredArgsConstructor;
+import rs.map.pki.model.User;
+
+@Getter
+@RequiredArgsConstructor
+public class PkiUserDetails implements UserDetails {
+
+    @JsonIgnore
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+}

--- a/back/src/main/resources/ValidationMessages.properties
+++ b/back/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,11 @@
+user.email.blank=Email cannot be blank.
+user.email.invalid=Email must be a valid email address.
+user.password.blank=Password cannot be blank.
+user.password.size=Password must be between {min} and {max} characters long.
+user.name.blank=Name cannot be blank.
+user.surname.blank=Surname cannot be blank.
+user.organization.blank=Organization cannot be blank.
+user.role.null=Role must be specified.
+
+login.email.blank=Please provide an email address.
+login.password.blank=Please provide a password.

--- a/back/src/main/resources/application.properties
+++ b/back/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.datasource.username=postgres
 spring.datasource.password=root
 
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.datasource.hikari.auto-commit=false
 
 spring.thymeleaf.check-template-location=false
@@ -13,3 +14,17 @@ spring.thymeleaf.check-template-location=false
 logging.level.org.springframework.web=DEBUG
 logging.level.org.springframework.security=TRACE
 logging.level.org.hibernate=ERROR
+
+server.port=8080
+server.ssl.enabled=true
+server.ssl.key-store-type=PKCS12
+# TODO: Use certificate that is not self-signed (store params as env vars)
+server.ssl.key-store=classpath:keystore.bart.p12
+server.ssl.key-store-password=changeMeLater
+server.ssl.key-store-alias=bart
+
+front.url=https://localhost:4200
+
+jwt.secret=f4f35c67e0eac4fba6e9bc2a1d88d1c0f2a3f0ae0b25ab9c97fbc92e2d57dfd9c81e739ffde7630c2b4b61dd208e477fb4dcb2ff21540ecbafad06c8c4196f4c
+jwt.accessExpiration=30m
+jwt.refreshExpiration=24h


### PR DESCRIPTION
Adds authentication via `jwt` bearer, with refresh tokens (also jwt, as cookie).  
Configures server to use https exclusively.

Some config should be changed in the future but overall ok.